### PR TITLE
feat: integrate with cover traffic epoch change support

### DIFF
--- a/LICENSE-APACHE-v2
+++ b/LICENSE-APACHE-v2
@@ -1,0 +1,190 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by the Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding any notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+Copyright (c) 2025 vacp2p
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 vacp2p
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mix_rln_spam_protection.nimble
+++ b/mix_rln_spam_protection.nimble
@@ -15,8 +15,8 @@ requires "nimcrypto >= 0.6.0"
 requires "secp256k1 >= 0.5.0"
 requires "json_serialization >= 0.2.0"
 
-# nim-libp2p with cover traffic support (PR #2243)
-requires "https://github.com/vacp2p/nim-libp2p.git#feat/cover-traffic"
+# nim-libp2p with cover traffic support (PR #2243 merged as e1bbda4f6)
+requires "https://github.com/vacp2p/nim-libp2p.git#e1bbda4f6"
 
 # Tasks
 task test, "Run tests":

--- a/mix_rln_spam_protection.nimble
+++ b/mix_rln_spam_protection.nimble
@@ -8,15 +8,15 @@ srcDir = "src"
 # Dependencies
 requires "nim >= 2.0.0"
 requires "results >= 0.4.0"
-requires "stew >= 0.1.0"
-requires "chronicles >= 0.10.0"
-requires "chronos >= 4.0.0"
+requires "stew >= 0.4.2"
+requires "chronicles >= 0.11.0"
+requires "chronos >= 4.2.2"
 requires "nimcrypto >= 0.6.0"
 requires "secp256k1 >= 0.5.0"
 requires "json_serialization >= 0.2.0"
 
-# nim-libp2p with mix spam protection (PR #2037 merged)
-requires "https://github.com/vacp2p/nim-libp2p.git#525a9dd3fb381c4e5fa4429cf0bf664814e4d67e"
+# nim-libp2p with cover traffic support (PR #2243)
+requires "https://github.com/vacp2p/nim-libp2p.git#feat/cover-traffic"
 
 # Tasks
 task test, "Run tests":

--- a/src/mix_rln_spam_protection/rln_interface.nim
+++ b/src/mix_rln_spam_protection/rln_interface.nim
@@ -8,7 +8,6 @@
 
 import std/os
 import results, chronicles
-import stew/arrayops
 import ./types
 import ./constants
 

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -7,7 +7,7 @@
 ## This module provides the MixRlnSpamProtection type that can be used with
 ## the mix protocol for per-hop proof generation and verification.
 
-import std/[options, deques]
+import std/[math, options, deques, times]
 import chronos
 import results
 import chronicles
@@ -187,9 +187,19 @@ proc init*(sp: MixRlnSpamProtection): Future[RlnResult[void]] {.async.} =
 proc runEpochTimer(sp: MixRlnSpamProtection) {.async: (raises: [CancelledError]).} =
   ## Background timer that detects epoch boundaries and fires OnEpochChange
   ## callbacks even when no proofs are being generated.
+  ##
+  ## Sleeps until the next absolute epoch boundary on each iteration to avoid
+  ## cumulative drift from processing overhead. This also ensures the first
+  ## tick aligns to the next real epoch boundary rather than
+  ## `startTime + epochDuration`.
   while sp.state != PluginState.Stopped:
-    # sleepAsync: epoch timer fires at fixed intervals
-    await sleepAsync(sp.config.epochDurationSeconds.int.seconds)
+    let
+      nowSec = getTime().toUnixFloat()
+      epochDur = sp.config.epochDurationSeconds
+      timeIntoEpoch = floorMod(nowSec, epochDur)
+      sleepMs = max(1, int((epochDur - timeIntoEpoch) * 1000.0))
+    await sleepAsync(sleepMs)
+
     let epoch = currentEpoch(sp.config.epochDurationSeconds)
     if epoch != sp.lastEpoch:
       sp.messageIdCounter = 0
@@ -228,8 +238,8 @@ proc stop*(sp: MixRlnSpamProtection) {.async.} =
 
   sp.state = PluginState.Stopped
 
-  if not sp.epochTimerLoop.isNil and not sp.epochTimerLoop.finished:
-    sp.epochTimerLoop.cancelSoon()
+  if not sp.epochTimerLoop.isNil:
+    await sp.epochTimerLoop.cancelAndWait()
 
   await sp.groupManager.stop()
   await sp.nullifierLog.stop()

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -11,6 +11,7 @@ import std/[math, options, deques, times]
 import chronos
 import results
 import chronicles
+import stew/endians2
 
 # Import nim-libp2p spam protection interface
 import libp2p/protocols/mix/spam_protection as libp2p_spam
@@ -184,6 +185,14 @@ proc init*(sp: MixRlnSpamProtection): Future[RlnResult[void]] {.async.} =
   info "MixRlnSpamProtection initialized, waiting for sync"
   ok()
 
+proc advanceEpoch(sp: MixRlnSpamProtection, epoch: Epoch) =
+  ## Reset all per-epoch state and notify listeners. Centralised so any new
+  ## per-epoch field (counters, pools, caches) only needs to be cleared here.
+  sp.messageIdCounter = 0
+  sp.freedMessageIds.clear()
+  sp.lastEpoch = epoch
+  sp.notifyEpochChange(epochToUint64(epoch))
+
 proc runEpochTimer(sp: MixRlnSpamProtection) {.async: (raises: [CancelledError]).} =
   ## Background timer that detects epoch boundaries and fires OnEpochChange
   ## callbacks even when no proofs are being generated.
@@ -202,10 +211,7 @@ proc runEpochTimer(sp: MixRlnSpamProtection) {.async: (raises: [CancelledError])
 
     let epoch = currentEpoch(sp.config.epochDurationSeconds)
     if epoch != sp.lastEpoch:
-      sp.messageIdCounter = 0
-      sp.freedMessageIds.clear()
-      sp.lastEpoch = epoch
-      sp.notifyEpochChange(epochToUint64(epoch))
+      sp.advanceEpoch(epoch)
 
 proc start*(sp: MixRlnSpamProtection): Future[RlnResult[void]] {.async.} =
   ## Start the spam protection plugin.
@@ -287,6 +293,42 @@ proc registerSelf*(
 
 # SpamProtection implementation
 
+# Proof token layout (opaque to callers):
+#   [epoch: 8 BE][messageId: 8 BE][merkleRoot: 32]
+const
+  ProofTokenEpochOffset = 0
+  ProofTokenMsgIdOffset = 8
+  ProofTokenRootOffset = 16
+  ProofTokenSize = ProofTokenRootOffset + sizeof(MerkleNode) # 48
+
+type ProofToken = object
+  epoch: uint64
+  messageId: uint64
+  merkleRoot: MerkleNode
+
+func encode(t: ProofToken): seq[byte] =
+  result = newSeq[byte](ProofTokenSize)
+  result[ProofTokenEpochOffset ..< ProofTokenMsgIdOffset] = t.epoch.toBytesBE()
+  result[ProofTokenMsgIdOffset ..< ProofTokenRootOffset] = t.messageId.toBytesBE()
+  copyMem(
+    addr result[ProofTokenRootOffset], unsafeAddr t.merkleRoot[0], sizeof(MerkleNode)
+  )
+
+func decode(T: type ProofToken, bytes: openArray[byte]): Result[ProofToken, string] =
+  if bytes.len != ProofTokenSize:
+    return err("invalid proof token length: " & $bytes.len)
+  var token: ProofToken
+  token.epoch = uint64.fromBytesBE(
+    bytes.toOpenArray(ProofTokenEpochOffset, ProofTokenMsgIdOffset - 1)
+  )
+  token.messageId = uint64.fromBytesBE(
+    bytes.toOpenArray(ProofTokenMsgIdOffset, ProofTokenRootOffset - 1)
+  )
+  copyMem(
+    addr token.merkleRoot[0], unsafeAddr bytes[ProofTokenRootOffset], sizeof(MerkleNode)
+  )
+  ok(token)
+
 method generateProof*(
     sp: MixRlnSpamProtection, bindingData: seq[byte]
 ): Result[libp2p_spam.ProofResult, string] {.gcsafe, raises: [].} =
@@ -307,10 +349,7 @@ method generateProof*(
   let epoch = currentEpoch(sp.config.epochDurationSeconds)
 
   if epoch != sp.lastEpoch:
-    sp.messageIdCounter = 0
-    sp.freedMessageIds.clear()
-    sp.lastEpoch = epoch
-    sp.notifyEpochChange(epochToUint64(epoch))
+    sp.advanceEpoch(epoch)
 
   # Reuse a freed messageId if available, otherwise allocate the next one.
   # Guard against exceeding userMessageLimit here so callers see a clear
@@ -343,20 +382,18 @@ method generateProof*(
   # Serialize proof using protobuf
   let serialized = proof.toBytes()
 
-  # Encode messageId (8 bytes) + merkleRoot (32 bytes) as opaque token
-  var token = newSeq[byte](8 + 32)
-  token[0] = byte(msgId shr 56)
-  token[1] = byte(msgId shr 48)
-  token[2] = byte(msgId shr 40)
-  token[3] = byte(msgId shr 32)
-  token[4] = byte(msgId shr 24)
-  token[5] = byte(msgId shr 16)
-  token[6] = byte(msgId shr 8)
-  token[7] = byte(msgId)
-  copyMem(addr token[8], unsafeAddr proof.merkleRoot[0], 32)
+  # Encode epoch + messageId + merkleRoot as opaque token.
+  # The epoch qualifier is critical for safe reclaim: a token built in
+  # epoch N must NOT be reclaimed into epoch N+1's freed pool, or the same
+  # (epoch, messageId) pair could be issued twice in N+1, causing an RLN
+  # double-signal (slashing risk).
+  let
+    epochU64 = epochToUint64(epoch)
+    token = ProofToken(
+      epoch: epochU64, messageId: msgId.uint64, merkleRoot: proof.merkleRoot
+    ).encode()
 
-  debug "Generated RLN proof successfully",
-    epoch = epochToUint64(epoch), messageId = msgId
+  debug "Generated RLN proof successfully", epoch = epochU64, messageId = msgId
 
   ok(libp2p_spam.ProofResult(proof: serialized, token: token))
 
@@ -364,15 +401,24 @@ method reclaimProofToken*(
     sp: MixRlnSpamProtection, token: seq[byte]
 ) {.gcsafe, raises: [].} =
   ## Reclaim a proof slot from a discarded precomputed cover packet.
-  ## Token format: [messageId: 8 bytes][merkleRoot: 32 bytes]
-  if token.len < 8:
+  ##
+  ## Cross-epoch reclaims are silently dropped: a token built in epoch N must
+  ## never be reclaimed in epoch N+1 because the messageId allocation is
+  ## per-epoch. Reusing a stale messageId from epoch N inside epoch N+1 would
+  ## risk a double-signal (and RLN slashing) once the counter naturally
+  ## reissues the same id.
+  let decoded = ProofToken.decode(token).valueOr:
+    trace "Malformed proof token - dropping reclaim", len = token.len
     return
-  let msgId =
-    (uint(token[0]) shl 56) or (uint(token[1]) shl 48) or (uint(token[2]) shl 40) or
-    (uint(token[3]) shl 32) or (uint(token[4]) shl 24) or (uint(token[5]) shl 16) or
-    (uint(token[6]) shl 8) or uint(token[7])
-  sp.freedMessageIds.addLast(msgId)
-  trace "Reclaimed proof token", messageId = msgId
+
+  let currentEpochU64 = epochToUint64(currentEpoch(sp.config.epochDurationSeconds))
+  if decoded.epoch != currentEpochU64:
+    trace "Cross-epoch proof token reclaim dropped",
+      tokenEpoch = decoded.epoch, currentEpoch = currentEpochU64
+    return
+
+  sp.freedMessageIds.addLast(uint(decoded.messageId))
+  trace "Reclaimed proof token", epoch = decoded.epoch, messageId = decoded.messageId
 
 method isProofTokenValid*(
     sp: MixRlnSpamProtection, token: seq[byte]
@@ -381,12 +427,10 @@ method isProofTokenValid*(
   ## acceptable roots window. If the root has fallen out of the window
   ## (due to membership changes), the prebuilt proof would be rejected
   ## by verifiers and the sender could be flagged as a spammer.
-  ## Token format: [messageId: 8 bytes][merkleRoot: 32 bytes]
-  if token.len != 40:
+  let decoded = ProofToken.decode(token).valueOr:
     trace "Malformed proof token - rejecting", len = token.len
     return false
-  var root: MerkleNode
-  copyMem(addr root[0], unsafeAddr token[8], 32)
+  let root = decoded.merkleRoot
   let valid = sp.groupManager.validateRoot(root)
   if not valid:
     trace "Prebuilt proof token has stale Merkle root",

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -7,7 +7,7 @@
 ## This module provides the MixRlnSpamProtection type that can be used with
 ## the mix protocol for per-hop proof generation and verification.
 
-import std/options
+import std/[options, deques]
 import chronos
 import results
 import chronicles
@@ -59,6 +59,7 @@ type
     nullifierLog: NullifierLog
     state: PluginState
     messageIdCounter: uint # Tracks messages within current epoch
+    freedMessageIds: Deque[uint] # Reclaimed IDs from discarded cover packets
     lastEpoch: Epoch
     publishCallback: Option[PublishCallback]
     spamHandler: Option[SpamHandler]
@@ -114,6 +115,7 @@ proc newMixRlnSpamProtection*(config: MixRlnConfig): RlnResult[MixRlnSpamProtect
       nullifierLog: nullifierLog,
       state: PluginState.Uninitialized,
       messageIdCounter: 0,
+      freedMessageIds: initDeque[uint](),
       lastEpoch: default(Epoch),
       publishCallback: none(PublishCallback),
       spamHandler: none(SpamHandler),
@@ -191,6 +193,7 @@ proc runEpochTimer(sp: MixRlnSpamProtection) {.async: (raises: [CancelledError])
     let epoch = currentEpoch(sp.config.epochDurationSeconds)
     if epoch != sp.lastEpoch:
       sp.messageIdCounter = 0
+      sp.freedMessageIds.clear()
       sp.lastEpoch = epoch
       sp.notifyEpochChange(epochToUint64(epoch))
 
@@ -276,11 +279,14 @@ proc registerSelf*(
 
 method generateProof*(
     sp: MixRlnSpamProtection, bindingData: seq[byte]
-): Result[seq[byte], string] {.gcsafe, raises: [].} =
+): Result[libp2p_spam.ProofResult, string] {.gcsafe, raises: [].} =
   ## Generate an RLN proof bound to the given packet data.
   ##
   ## For per-hop generation, bindingData is the outgoing Sphinx packet.
   ## The proof is generated using the node's credentials and current epoch.
+  ## Returns a ProofResult with the proof and an opaque token encoding the
+  ## messageId used, which can be reclaimed via reclaimProofToken if the
+  ## packet is discarded before sending.
 
   trace "MixRlnSpamProtection.generateProof called", bindingDataLen = bindingData.len
 
@@ -292,33 +298,82 @@ method generateProof*(
 
   if epoch != sp.lastEpoch:
     sp.messageIdCounter = 0
+    sp.freedMessageIds.clear()
     sp.lastEpoch = epoch
     sp.notifyEpochChange(epochToUint64(epoch))
 
-  # Note: Rate limit enforcement happens in zerokit's generate_rln_proof_with_witness FFI call,
-  # which validates messageId < userMessageLimit internally. No need to check here.
+  # Reuse a freed messageId if available, otherwise allocate the next one
+  let msgId =
+    if sp.freedMessageIds.len > 0:
+      sp.freedMessageIds.popFirst()
+    else:
+      let id = sp.messageIdCounter
+      sp.messageIdCounter += 1
+      id
 
   trace "Calling groupManager.generateProof",
     bindingDataLen = bindingData.len,
-    messageId = sp.messageIdCounter
+    messageId = msgId,
+    reused = (msgId < sp.messageIdCounter)
 
   # Generate proof
   let proof = sp.groupManager.generateProof(
-    bindingData, epoch, sp.config.rlnIdentifier, sp.messageIdCounter
+    bindingData, epoch, sp.config.rlnIdentifier, msgId
   ).valueOr:
     error "GroupManager proof generation failed", error = error
     return err("Failed to generate proof: " & error)
 
-  sp.messageIdCounter += 1
-
   # Serialize proof using protobuf
   let serialized = proof.toBytes()
 
-  debug "Generated RLN proof successfully",
-    epoch = epochToUint64(epoch),
-    messageId = sp.messageIdCounter - 1
+  # Encode messageId (8 bytes) + merkleRoot (32 bytes) as opaque token
+  var token = newSeq[byte](8 + 32)
+  token[0] = byte(msgId shr 56)
+  token[1] = byte(msgId shr 48)
+  token[2] = byte(msgId shr 40)
+  token[3] = byte(msgId shr 32)
+  token[4] = byte(msgId shr 24)
+  token[5] = byte(msgId shr 16)
+  token[6] = byte(msgId shr 8)
+  token[7] = byte(msgId)
+  copyMem(addr token[8], unsafeAddr proof.merkleRoot[0], 32)
 
-  ok(serialized)
+  debug "Generated RLN proof successfully",
+    epoch = epochToUint64(epoch), messageId = msgId
+
+  ok(libp2p_spam.ProofResult(proof: serialized, token: token))
+
+method reclaimProofToken*(
+    sp: MixRlnSpamProtection, token: seq[byte]
+) {.gcsafe, raises: [].} =
+  ## Reclaim a proof slot from a discarded precomputed cover packet.
+  ## Token format: [messageId: 8 bytes][merkleRoot: 32 bytes]
+  if token.len < 8:
+    return
+  let msgId =
+    (uint(token[0]) shl 56) or (uint(token[1]) shl 48) or (uint(token[2]) shl 40) or
+    (uint(token[3]) shl 32) or (uint(token[4]) shl 24) or (uint(token[5]) shl 16) or
+    (uint(token[6]) shl 8) or uint(token[7])
+  sp.freedMessageIds.addLast(msgId)
+  trace "Reclaimed proof token", messageId = msgId
+
+method isProofTokenValid*(
+    sp: MixRlnSpamProtection, token: seq[byte]
+): bool {.gcsafe, raises: [].} =
+  ## Check if the Merkle root embedded in the proof token is still in the
+  ## acceptable roots window. If the root has fallen out of the window
+  ## (due to membership changes), the prebuilt proof would be rejected
+  ## by verifiers and the sender could be flagged as a spammer.
+  ## Token format: [messageId: 8 bytes][merkleRoot: 32 bytes]
+  if token.len < 40:
+    return true # No root info available, assume valid
+  var root: MerkleNode
+  copyMem(addr root[0], unsafeAddr token[8], 32)
+  let valid = sp.groupManager.validateRoot(root)
+  if not valid:
+    trace "Prebuilt proof token has stale Merkle root",
+      root = root[0 .. 7].toHex() & "..."
+  valid
 
 {.pop.}
 
@@ -387,9 +442,7 @@ proc handleSpamDetected(
       await sp.spamHandler.get()(proof, secret, 0)
 
 method verifyProof*(
-    sp: MixRlnSpamProtection,
-    encodedProofData: seq[byte],
-    bindingData: seq[byte],
+    sp: MixRlnSpamProtection, encodedProofData: seq[byte], bindingData: seq[byte]
 ): Result[bool, string] {.gcsafe, raises: [].} =
   ## Verify an RLN proof and check for spam.
   ##
@@ -422,9 +475,7 @@ method verifyProof*(
     return ok(false)
 
   # Verify the zkSNARK proof
-  let isValid = sp.groupManager.verifyProof(
-    proof, bindingData, sp.config.rlnIdentifier
-  ).valueOr:
+  let isValid = sp.groupManager.verifyProof(proof, bindingData, sp.config.rlnIdentifier).valueOr:
     return err("Proof verification error: " & error)
 
   if not isValid:
@@ -481,14 +532,10 @@ method verifyProof*(
 
   ok(true)
 
-method epochDurationSeconds*(
-    sp: MixRlnSpamProtection
-): float64 {.gcsafe, raises: [].} =
+method epochDurationSeconds*(sp: MixRlnSpamProtection): float64 {.gcsafe, raises: [].} =
   sp.config.epochDurationSeconds
 
-method rateLimitBudget*(
-    sp: MixRlnSpamProtection
-): int {.gcsafe, raises: [].} =
+method rateLimitBudget*(sp: MixRlnSpamProtection): int {.gcsafe, raises: [].} =
   sp.config.userMessageLimit
 
 # Coordination layer handlers
@@ -534,8 +581,7 @@ proc loadTree*(sp: MixRlnSpamProtection): RlnResult[void] =
   if loadResult.isOk:
     let memberCount = sp.groupManager.getMemberCount()
     debug "Tree loaded from file",
-      treePath = sp.config.treePath,
-      memberCount = memberCount
+      treePath = sp.config.treePath, memberCount = memberCount
   loadResult
 
 proc restoreCredentialsToTree*(sp: MixRlnSpamProtection): RlnResult[void] =

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -382,8 +382,9 @@ method isProofTokenValid*(
   ## (due to membership changes), the prebuilt proof would be rejected
   ## by verifiers and the sender could be flagged as a spammer.
   ## Token format: [messageId: 8 bytes][merkleRoot: 32 bytes]
-  if token.len < 40:
-    return true # No root info available, assume valid
+  if token.len != 40:
+    trace "Malformed proof token - rejecting", len = token.len
+    return false
   var root: MerkleNode
   copyMem(addr root[0], unsafeAddr token[8], 32)
   let valid = sp.groupManager.validateRoot(root)

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -201,13 +201,21 @@ proc runEpochTimer(sp: MixRlnSpamProtection) {.async: (raises: [CancelledError])
   ## cumulative drift from processing overhead. This also ensures the first
   ## tick aligns to the next real epoch boundary rather than
   ## `startTime + epochDuration`.
+  ##
+  ## A 1 ms epsilon is added to `sleepMs` so we wake strictly *after* the
+  ## boundary: `calcEpoch` uses ceil semantics, so the boundary time itself
+  ## (e.g. t == 10.0 for epochDur == 10) still belongs to the previous epoch.
+  ## Without the epsilon, a wake-up landing exactly on the boundary would see
+  ## the old epoch and miss the transition for a full period.
   while sp.state != PluginState.Stopped:
     let
       nowSec = getTime().toUnixFloat()
       epochDur = sp.config.epochDurationSeconds
       timeIntoEpoch = floorMod(nowSec, epochDur)
-      sleepMs = max(1, int((epochDur - timeIntoEpoch) * 1000.0))
-    await sleepAsync(sleepMs)
+      sleepMs = max(1, int((epochDur - timeIntoEpoch) * 1000.0)) + 1
+    # chronos.milliseconds is qualified to disambiguate from std/times.milliseconds
+    # (which returns TimeInterval, not chronos.Duration).
+    await sleepAsync(chronos.milliseconds(sleepMs))
 
     let epoch = currentEpoch(sp.config.epochDurationSeconds)
     if epoch != sp.lastEpoch:
@@ -354,9 +362,9 @@ method generateProof*(
   # Reuse a freed messageId if available, otherwise allocate the next one.
   # Guard against exceeding userMessageLimit here so callers see a clear
   # rate-limit error instead of a cryptic failure from deep inside RLN.
-  let msgId =
+  let (msgId, reused) =
     if sp.freedMessageIds.len > 0:
-      sp.freedMessageIds.popFirst()
+      (sp.freedMessageIds.popFirst(), true)
     else:
       let id = sp.messageIdCounter
       if id >= uint(sp.config.userMessageLimit):
@@ -365,12 +373,10 @@ method generateProof*(
             $sp.config.userMessageLimit & ")"
         )
       sp.messageIdCounter += 1
-      id
+      (id, false)
 
   trace "Calling groupManager.generateProof",
-    bindingDataLen = bindingData.len,
-    messageId = msgId,
-    reused = (msgId < sp.messageIdCounter)
+    bindingDataLen = bindingData.len, messageId = msgId, reused = reused
 
   # Generate proof
   let proof = sp.groupManager.generateProof(
@@ -402,11 +408,15 @@ method reclaimProofToken*(
 ) {.gcsafe, raises: [].} =
   ## Reclaim a proof slot from a discarded precomputed cover packet.
   ##
-  ## Cross-epoch reclaims are silently dropped: a token built in epoch N must
-  ## never be reclaimed in epoch N+1 because the messageId allocation is
-  ## per-epoch. Reusing a stale messageId from epoch N inside epoch N+1 would
-  ## risk a double-signal (and RLN slashing) once the counter naturally
-  ## reissues the same id.
+  ## Drops the reclaim silently (trace only) on any of:
+  ##   - malformed token
+  ##   - cross-epoch token (epoch N reclaimed in epoch N+1)
+  ##   - out-of-range messageId (>= userMessageLimit)
+  ##   - messageId not yet allocated in this epoch (>= messageIdCounter)
+  ##   - duplicate reclaim of an id already in the freed pool
+  ##
+  ## Each guard prevents the same (epoch, messageId) pair from being issued
+  ## twice in one epoch — i.e. an RLN double-signal / slashing risk.
   let decoded = ProofToken.decode(token).valueOr:
     trace "Malformed proof token - dropping reclaim", len = token.len
     return
@@ -417,7 +427,26 @@ method reclaimProofToken*(
       tokenEpoch = decoded.epoch, currentEpoch = currentEpochU64
     return
 
-  sp.freedMessageIds.addLast(uint(decoded.messageId))
+  if decoded.messageId >= uint64(sp.config.userMessageLimit):
+    trace "Out-of-range messageId in reclaim - dropping",
+      messageId = decoded.messageId, limit = sp.config.userMessageLimit
+    return
+
+  if decoded.messageId >= sp.messageIdCounter.uint64:
+    trace "Reclaim of unallocated messageId - dropping",
+      messageId = decoded.messageId, counter = sp.messageIdCounter
+    return
+
+  # Linear scan for duplicate is O(N) but N is bounded by userMessageLimit;
+  # this keeps the hot generateProof path scan-free.
+  let id = uint(decoded.messageId)
+  for existing in sp.freedMessageIds:
+    if existing == id:
+      trace "Duplicate proof token reclaim - dropping",
+        epoch = decoded.epoch, messageId = decoded.messageId
+      return
+
+  sp.freedMessageIds.addLast(id)
   trace "Reclaimed proof token", epoch = decoded.epoch, messageId = decoded.messageId
 
 method isProofTokenValid*(

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -62,6 +62,7 @@ type
     lastEpoch: Epoch
     publishCallback: Option[PublishCallback]
     spamHandler: Option[SpamHandler]
+    epochTimerLoop: Future[void]
 
 proc defaultRlnIdentifier*(): RlnIdentifier =
   ## Get the default RLN identifier.
@@ -181,25 +182,37 @@ proc init*(sp: MixRlnSpamProtection): Future[RlnResult[void]] {.async.} =
   info "MixRlnSpamProtection initialized, waiting for sync"
   ok()
 
+proc runEpochTimer(sp: MixRlnSpamProtection) {.async: (raises: [CancelledError]).} =
+  ## Background timer that detects epoch boundaries and fires OnEpochChange
+  ## callbacks even when no proofs are being generated.
+  while sp.state != PluginState.Stopped:
+    # sleepAsync: epoch timer fires at fixed intervals
+    await sleepAsync(sp.config.epochDurationSeconds.int.seconds)
+    let epoch = currentEpoch(sp.config.epochDurationSeconds)
+    if epoch != sp.lastEpoch:
+      sp.messageIdCounter = 0
+      sp.lastEpoch = epoch
+      sp.notifyEpochChange(epochToUint64(epoch))
+
 proc start*(sp: MixRlnSpamProtection): Future[RlnResult[void]] {.async.} =
   ## Start the spam protection plugin.
   ##
-  ## This starts the group manager sync and nullifier log cleanup.
+  ## This starts the group manager sync, nullifier log cleanup,
+  ## and epoch boundary detection timer.
   ## After start() completes, the plugin is in Ready state.
 
   if sp.state == PluginState.Uninitialized:
     return err("Plugin not initialized")
 
   if sp.state == PluginState.Ready:
-    return ok() # Already started
+    return ok()
 
-  # Start group manager
   let gmStartResult = await sp.groupManager.start()
   if gmStartResult.isErr:
     return err("Failed to start group manager: " & gmStartResult.error)
 
-  # Start nullifier log cleanup
   sp.nullifierLog.start()
+  sp.epochTimerLoop = sp.runEpochTimer()
 
   sp.state = PluginState.Ready
   info "MixRlnSpamProtection started"
@@ -210,10 +223,14 @@ proc stop*(sp: MixRlnSpamProtection) {.async.} =
   if sp.state == PluginState.Stopped:
     return
 
+  sp.state = PluginState.Stopped
+
+  if not sp.epochTimerLoop.isNil and not sp.epochTimerLoop.finished:
+    sp.epochTimerLoop.cancelSoon()
+
   await sp.groupManager.stop()
   await sp.nullifierLog.stop()
 
-  sp.state = PluginState.Stopped
   info "MixRlnSpamProtection stopped"
 
 {.push raises: [], gcsafe.}
@@ -273,10 +290,10 @@ method generateProof*(
 
   let epoch = currentEpoch(sp.config.epochDurationSeconds)
 
-  # Reset message counter if epoch changed
   if epoch != sp.lastEpoch:
     sp.messageIdCounter = 0
     sp.lastEpoch = epoch
+    sp.notifyEpochChange(epochToUint64(epoch))
 
   # Note: Rate limit enforcement happens in zerokit's generate_rln_proof_with_witness FFI call,
   # which validates messageId < userMessageLimit internally. No need to check here.
@@ -463,6 +480,16 @@ method verifyProof*(
     nullifier = proof.nullifier[0 .. 7].toHex() & "..."
 
   ok(true)
+
+method epochDurationSeconds*(
+    sp: MixRlnSpamProtection
+): float64 {.gcsafe, raises: [].} =
+  sp.config.epochDurationSeconds
+
+method rateLimitBudget*(
+    sp: MixRlnSpamProtection
+): int {.gcsafe, raises: [].} =
+  sp.config.userMessageLimit
 
 # Coordination layer handlers
 

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -312,12 +312,19 @@ method generateProof*(
     sp.lastEpoch = epoch
     sp.notifyEpochChange(epochToUint64(epoch))
 
-  # Reuse a freed messageId if available, otherwise allocate the next one
+  # Reuse a freed messageId if available, otherwise allocate the next one.
+  # Guard against exceeding userMessageLimit here so callers see a clear
+  # rate-limit error instead of a cryptic failure from deep inside RLN.
   let msgId =
     if sp.freedMessageIds.len > 0:
       sp.freedMessageIds.popFirst()
     else:
       let id = sp.messageIdCounter
+      if id >= uint(sp.config.userMessageLimit):
+        return err(
+          "Message rate limit exceeded for current epoch (messageId=" & $id & ", limit=" &
+            $sp.config.userMessageLimit & ")"
+        )
       sp.messageIdCounter += 1
       id
 

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -23,6 +23,7 @@ import ../src/mix_rln_spam_protection/constants
 import ../src/mix_rln_spam_protection/codec
 import ../src/mix_rln_spam_protection/nullifier_log
 import ../src/mix_rln_spam_protection/rln_interface
+import libp2p/protocols/mix/spam_protection as libp2p_spam
 
 # Use std/unittest (testutils/unittests available in logos-messaging-nim context)
 import std/unittest
@@ -749,6 +750,45 @@ suite "Partial Proof Cache and Root Tracking":
 
     check not targetGm.validateRoot(emptyRoot.get())
     check targetGm.validateRoot(snapshotRoot.get())
+
+suite "Epoch Change Notification":
+  test "epochDurationSeconds returns configured value":
+    let config = MixRlnConfig(epochDurationSeconds: 15.0)
+    let sp = newMixRlnSpamProtection(config)
+    check sp.isOk
+    check sp.get().epochDurationSeconds() == 15.0
+
+  test "rateLimitBudget returns configured userMessageLimit":
+    let config = MixRlnConfig(userMessageLimit: 50)
+    let sp = newMixRlnSpamProtection(config)
+    check sp.isOk
+    check sp.get().rateLimitBudget() == 50
+
+  test "registered epoch change callback fires on generateProof":
+    let config = defaultConfig()
+    let sp = newMixRlnSpamProtection(config)
+    check sp.isOk
+    let plugin = sp.get()
+
+    let initResult = waitFor plugin.init()
+    check initResult.isOk
+    let registerResult = waitFor plugin.registerSelf()
+    check registerResult.isOk
+    let startResult = waitFor plugin.start()
+    check startResult.isOk
+
+    var receivedEpoch: uint64 = 0
+    plugin.registerOnEpochChange(
+      proc(epoch: uint64) {.gcsafe, raises: [].} =
+        receivedEpoch = epoch
+    )
+
+    let proofResult = plugin.generateProof(@[byte(1), 2, 3])
+    check proofResult.isOk
+    # First call sets lastEpoch, callback fires with current epoch
+    check receivedEpoch > 0
+
+    waitFor plugin.stop()
 
 # Main test runner
 when isMainModule:

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -608,7 +608,7 @@ suite "Spam Detection and Secret Recovery":
     let bindingData = @[byte(10), 20, 30, 40, 50]
     let proofResult = sp.generateProof(bindingData)
     check proofResult.isOk
-    let proofBytes = proofResult.get()
+    let proofBytes = proofResult.get().proof
 
     # Verify the proof
     let verifyResult = sp.verifyProof(proofBytes, bindingData)

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -753,14 +753,16 @@ suite "Partial Proof Cache and Root Tracking":
 
 suite "Epoch Change Notification":
   test "epochDurationSeconds returns configured value":
-    let config = MixRlnConfig(epochDurationSeconds: 15.0)
-    let sp = newMixRlnSpamProtection(config)
+    var cfg = defaultConfig()
+    cfg.epochDurationSeconds = 15.0
+    let sp = newMixRlnSpamProtection(cfg)
     check sp.isOk
     check sp.get().epochDurationSeconds() == 15.0
 
   test "rateLimitBudget returns configured userMessageLimit":
-    let config = MixRlnConfig(userMessageLimit: 50)
-    let sp = newMixRlnSpamProtection(config)
+    var cfg = defaultConfig()
+    cfg.userMessageLimit = 50
+    let sp = newMixRlnSpamProtection(cfg)
     check sp.isOk
     check sp.get().rateLimitBudget() == 50
 
@@ -787,6 +789,32 @@ suite "Epoch Change Notification":
     check proofResult.isOk
     # First call sets lastEpoch, callback fires with current epoch
     check receivedEpoch > 0
+
+    waitFor plugin.stop()
+
+  test "epoch change callback fires from background timer while idle":
+    # Exercises the background runEpochTimer path: no generateProof calls
+    # are made, so the callback can only fire if the timer detected a
+    # boundary on its own.
+    var cfg = defaultConfig()
+    cfg.epochDurationSeconds = 1.0
+    let sp = newMixRlnSpamProtection(cfg)
+    check sp.isOk
+    let plugin = sp.get()
+
+    check (waitFor plugin.init()).isOk
+    check (waitFor plugin.registerSelf()).isOk
+    check (waitFor plugin.start()).isOk
+
+    var fired = false
+    plugin.registerOnEpochChange(
+      proc(epoch: uint64) {.gcsafe, raises: [].} =
+        fired = true
+    )
+
+    # Sleep > 1 epoch so at least one boundary must be crossed.
+    waitFor sleepAsync(1500.milliseconds)
+    check fired
 
     waitFor plugin.stop()
 


### PR DESCRIPTION
## Summary

Integrates the RLN spam protection plugin with nim-libp2p's cover traffic epoch change mechanism. This enables cover traffic to receive epoch boundary notifications from the DoS protection layer, as defined in Mix DoS Protection spec §8.2.3.

Changes:
- Override `epochDurationSeconds` and `rateLimitBudget` on `SpamProtection` base type
- Call `notifyEpochChange` when epoch transitions are detected in `generateProof`
- Add background epoch timer to detect epoch boundaries even when idle (no proof generation)
- Add license files (`LICENSE-MIT`, `LICENSE-APACHE-v2`) — closes #1
- Bump nim-libp2p to `feat/cover-traffic` branch, align chronos/stew/chronicles versions

## Dependencies

- nim-libp2p PR: [vacp2p/nim-libp2p#2243](https://github.com/vacp2p/nim-libp2p/pull/2243)

## Testing

- All 28 tests pass (25 existing + 3 new epoch change tests)
- New tests verify `epochDurationSeconds`/`rateLimitBudget` overrides and callback firing on `generateProof`