### PR TITLE
chore: migrate to libp2p_mix package

### DIFF
--- a/mix_rln_spam_protection.nimble
+++ b/mix_rln_spam_protection.nimble
@@ -15,8 +15,11 @@ requires "nimcrypto >= 0.6.0"
 requires "secp256k1 >= 0.5.0"
 requires "json_serialization >= 0.2.0"
 
-# nim-libp2p with cover traffic support (PR #2243 merged as e1bbda4f6)
+# nim-libp2p — used directly for protobuf/minprotobuf and varint
 requires "https://github.com/vacp2p/nim-libp2p.git#e1bbda4f6"
+
+# libp2p_mix — extracted into its own repo; previously libp2p/protocols/mix
+requires "https://github.com/logos-co/nim-libp2p-mix.git#master"
 
 # Tasks
 task test, "Run tests":

--- a/mix_rln_spam_protection.nimble
+++ b/mix_rln_spam_protection.nimble
@@ -19,7 +19,7 @@ requires "json_serialization >= 0.2.0"
 requires "https://github.com/vacp2p/nim-libp2p.git#e1bbda4f6"
 
 # libp2p_mix — extracted into its own repo; previously libp2p/protocols/mix
-requires "https://github.com/logos-co/nim-libp2p-mix.git#master"
+requires "https://github.com/logos-co/nim-libp2p-mix.git#f24cd25a54e2156d66b497f6d576aab3ccfc8fa6"
 
 # Tasks
 task test, "Run tests":

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 vacp2p
 # Licensed under either of Apache License 2.0 or MIT license.
 
-## Main spam protection interface implementing the nim-libp2p SpamProtectionInterface.
+## Main spam protection interface implementing the libp2p_mix SpamProtectionInterface.
 ##
 ## This module provides the MixRlnSpamProtection type that can be used with
 ## the mix protocol for per-hop proof generation and verification.
@@ -13,7 +13,7 @@ import results
 import chronicles
 import stew/endians2
 
-# Import nim-libp2p spam protection interface
+# Import libp2p_mix spam protection interface
 import libp2p_mix/spam_protection as libp2p_spam
 
 import ./types
@@ -25,7 +25,7 @@ import ./nullifier_log
 import ./credentials
 
 export types, constants, codec, group_manager, nullifier_log, credentials
-# Re-export nim-libp2p types for convenience
+# Re-export libp2p_mix types for convenience
 export libp2p_spam.SpamProtection
 
 logScope:
@@ -48,11 +48,11 @@ type
     proofMetadataContentTopic*: string
       ## Content topic for broadcasting proof metadata. Default: "/mix/rln/metadata/v1"
 
-  # Main spam protection implementation - inherits from nim-libp2p interface
+  # Main spam protection implementation - inherits from libp2p_mix interface
   MixRlnSpamProtection* = ref object of libp2p_spam.SpamProtection
     ## RLN-based spam protection for mix networks.
     ##
-    ## Implements the SpamProtection interface from nim-libp2p for
+    ## Implements the SpamProtection interface from libp2p_mix for
     ## per-hop proof generation and verification.
     config: MixRlnConfig
     rlnInstance: RLNInstance

--- a/src/mix_rln_spam_protection/spam_protection.nim
+++ b/src/mix_rln_spam_protection/spam_protection.nim
@@ -14,7 +14,7 @@ import chronicles
 import stew/endians2
 
 # Import nim-libp2p spam protection interface
-import libp2p/protocols/mix/spam_protection as libp2p_spam
+import libp2p_mix/spam_protection as libp2p_spam
 
 import ./types
 import ./constants

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -23,7 +23,7 @@ import ../src/mix_rln_spam_protection/constants
 import ../src/mix_rln_spam_protection/codec
 import ../src/mix_rln_spam_protection/nullifier_log
 import ../src/mix_rln_spam_protection/rln_interface
-import libp2p/protocols/mix/spam_protection as libp2p_spam
+import libp2p_mix/spam_protection as libp2p_spam
 
 # Use std/unittest (testutils/unittests available in logos-messaging-nim context)
 import std/unittest


### PR DESCRIPTION
## Summary

Mix has been extracted out of `nim-libp2p` into its own package at
[`logos-co/nim-libp2p-mix`](https://github.com/logos-co/nim-libp2p-mix).
This PR updates the spam-protection plugin to import the abstract base
from the new location.

## Changes

- 2 import path changes: `libp2p/protocols/mix/spam_protection` → `libp2p_mix/spam_protection`
- 1 nimble dep added: `requires "https://github.com/logos-co/nim-libp2p-mix.git#master"`
- The existing `libp2p` dep stays — `protobuf/minprotobuf` and `varint` are still imported directly from libp2p core.

## Test plan

- [x] All 28 unit tests pass against the new `libp2p_mix` package (`nimble test` equivalent run with explicit paths)
- [x] No regressions: spam protection flow, RLN proof generation, nullifier log, snapshot replace, epoch-change callbacks all green
- [x] Verified downstream in `logos-delivery` end-to-end mixnet simulation (5-node mixnet + chat2mix publishing through mix)

## Companion PRs

- https://github.com/logos-messaging/logos-delivery/pull/3842 — bumps this submodule and updates waku imports
- https://github.com/vacp2p/nim-libp2p/pull/2378 — removes the now-extracted mix code