### PR TITLE
feat: bump zerokit to v2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ nimbledeps/
 librln.a
 src/mix_rln_spam_protection/rln_interface
 tests/test_all
+nimble.develop
+nimble.paths

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This plugin provides:
 │    - verifyProof(proof, bindingData) → bool                     │
 │    - proofSize() → 301 bytes (protobuf-encoded)                 │
 ├─────────────────────────────────────────────────────────────────┤
-│  RLN Core (zerokit v2.0.0 FFI)                                  │
+│  RLN Core (zerokit v2.0.2 FFI)                                  │
 │    - Proof generation/verification (RLN-v2 format)              │
 │    - Partial-proof caching for faster steady-state sends         │
 │    - Merkle tree operations                                      │
@@ -48,18 +48,21 @@ This plugin provides:
 
 ### Zerokit Library (librln)
 
-This plugin requires the zerokit RLN library (v2.0.0) for proof generation and verification.
+This plugin requires the zerokit RLN library (v2.0.2) for proof generation and verification.
+
+The plugin keeps a local Merkle tree (offchain membership), so zerokit must be
+built with default features — do **not** enable the `stateless` cargo feature.
 
 ```bash
 # Option 1: Build from source
 git clone https://github.com/vacp2p/zerokit
 cd zerokit
-git checkout v2.0.0
+git checkout v2.0.2
 cargo build --release -p rln
 cp target/release/librln.a /path/to/your/project/
 
 # Option 2: Download prebuilt
-# https://github.com/vacp2p/zerokit/releases/tag/v2.0.0
+# https://github.com/vacp2p/zerokit/releases/tag/v2.0.2
 ```
 
 ## Installation
@@ -72,7 +75,7 @@ requires "mix_rln_spam_protection >= 0.1.0"
 
 ### Dependencies
 
-- [zerokit-rln](https://github.com/vacp2p/zerokit) v2.0.0 - RLN proving library (static linking)
+- [zerokit-rln](https://github.com/vacp2p/zerokit) v2.0.2 - RLN proving library (static linking, default features — no `stateless`)
 - nim >= 2.0.0
 - chronos, results, chronicles, nimcrypto
 
@@ -236,7 +239,7 @@ nim c -r --passL:/path/to/librln.a --passL:-lm tests/test_all.nim
 - [RLN Spam Protection for Mix Networks RFC](https://github.com/vacp2p/rfc-index/pull/252)
 - [nim-libp2p Spam Protection Interface](https://github.com/vacp2p/nim-libp2p/pull/2037)
 - [RLN Documentation](https://rate-limiting-nullifier.github.io/rln-docs/)
-- [Zerokit](https://github.com/vacp2p/zerokit) (v0.9.0)
+- [Zerokit](https://github.com/vacp2p/zerokit) (v2.0.2)
 - [logos-messaging-nim](https://github.com/logos-messaging/logos-messaging-nim)
 
 ## License

--- a/src/mix_rln_spam_protection/rln_interface.nim
+++ b/src/mix_rln_spam_protection/rln_interface.nim
@@ -15,7 +15,7 @@ import results, chronicles
 import ./types
 import ./constants
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 logScope:
   topics = "rln interface"
@@ -103,7 +103,7 @@ const
 
 proc computeExternalNullifier*(
     epoch: Epoch, rlnIdentifier: RlnIdentifier
-): RlnResult[ExternalNullifier] {.gcsafe.}
+): RlnResult[ExternalNullifier]
 
 proc ffi_cfr_free(cfr: ptr CFr) {.importc: "ffi_cfr_free", cdecl.}
 proc ffi_cfr_to_bytes_le(cfr: ptr CFr): Vec_uint8 {.importc: "ffi_cfr_to_bytes_le", cdecl.}
@@ -133,6 +133,7 @@ proc ffi_rln_new_with_params(
   graph_data: ptr Vec_uint8,
   config: cstring,
 ): CResultRLNPtrVecU8 {.importc: "ffi_rln_new_with_params", cdecl.}
+proc ffi_rln_free(rln: ptr FFI_RLN) {.importc: "ffi_rln_free", cdecl.}
 
 proc ffi_rln_witness_input_new(
   identity_secret: ptr CFr,
@@ -166,11 +167,6 @@ proc ffi_finish_rln_proof(
   partial_proof: ptr ptr FFI_RLNPartialProof,
   witness: ptr ptr FFI_RLNWitnessInput,
 ): CResultProofPtrVecU8 {.importc: "ffi_finish_rln_proof", cdecl.}
-proc ffi_verify_rln_proof(
-  rln: ptr ptr FFI_RLN,
-  proof: ptr ptr FFI_RLNProof,
-  x: ptr CFr,
-): CBoolResult {.importc: "ffi_verify_rln_proof", cdecl.}
 proc ffi_verify_with_roots(
   rln: ptr ptr FFI_RLN,
   proof: ptr ptr FFI_RLNProof,
@@ -197,7 +193,6 @@ proc ffi_compute_id_secret(
 
 proc ffi_rln_proof_get_values(proof: ptr ptr FFI_RLNProof): ptr FFI_RLNProofValues {.importc: "ffi_rln_proof_get_values", cdecl.}
 proc ffi_rln_proof_to_bytes_le(proof: ptr ptr FFI_RLNProof): CResultVecU8VecU8 {.importc: "ffi_rln_proof_to_bytes_le", cdecl.}
-proc ffi_bytes_le_to_rln_proof(bytes: ptr Vec_uint8): CResultProofPtrVecU8 {.importc: "ffi_bytes_le_to_rln_proof", cdecl.}
 # v2.0.2: construct an RLNProof directly from its field elements (single
 # message-id variant), avoiding the manual 290-byte wire layout.
 proc ffi_rln_proof_new(
@@ -417,15 +412,20 @@ proc getMerkleProofRaw(
     return err(consumeError("Failed to get Merkle proof: ", res.err))
   ok(res.ok)
 
-proc buildWitness(
-    merkleProof: ptr FFI_MerkleProof,
+proc buildWitnessFromPath(
+    pathElements: ptr Vec_CFr,
+    pathIndex: ptr Vec_uint8,
     credential: IdentityCredential,
     epoch: Epoch,
     rlnIdentifier: RlnIdentifier,
     signal: openArray[byte],
     messageId: uint,
     userMessageLimit: uint64,
-): RlnResult[ptr FFI_RLNWitnessInput] {.gcsafe.} =
+    errPrefix: string,
+): RlnResult[ptr FFI_RLNWitnessInput] =
+  ## Build a witness from a caller-prepared Merkle path. Both overloads of
+  ## `buildWitness` funnel through here once their path inputs are in the
+  ## FFI-shaped Vec form.
   let identitySecret = bytesToCfrLe(credential.idSecretHash).valueOr:
     return err(error)
   defer:
@@ -458,16 +458,39 @@ proc buildWitness(
     identitySecret,
     userLimit,
     messageIdFr,
-    addr merkleProof[].path_elements,
-    addr merkleProof[].path_index,
+    pathElements,
+    pathIndex,
     x,
     externalNullifier,
   )
 
   if witnessRes.ok.isNil:
-    return err(consumeError("Failed to create witness: ", witnessRes.err))
+    return err(consumeError(errPrefix, witnessRes.err))
 
   ok(witnessRes.ok)
+
+proc buildWitness(
+    merkleProof: ptr FFI_MerkleProof,
+    credential: IdentityCredential,
+    epoch: Epoch,
+    rlnIdentifier: RlnIdentifier,
+    signal: openArray[byte],
+    messageId: uint,
+    userMessageLimit: uint64,
+): RlnResult[ptr FFI_RLNWitnessInput] =
+  ## Fast path: pass zerokit's owned `Vec_CFr` straight through; no
+  ## per-element bytes round-trip.
+  buildWitnessFromPath(
+    addr merkleProof[].path_elements,
+    addr merkleProof[].path_index,
+    credential,
+    epoch,
+    rlnIdentifier,
+    signal,
+    messageId,
+    userMessageLimit,
+    "Failed to create witness: ",
+  )
 
 proc buildWitness(
     pathElements: openArray[byte],
@@ -478,7 +501,10 @@ proc buildWitness(
     signal: openArray[byte],
     messageId: uint,
     userMessageLimit: uint64,
-): RlnResult[ptr FFI_RLNWitnessInput] {.gcsafe.} =
+): RlnResult[ptr FFI_RLNWitnessInput] =
+  ## Cached-cache path: reconstruct a `Vec_CFr` from the cached bytes so the
+  ## partial-proof reuse flow can rebuild the witness without holding a live
+  ## `FFI_MerkleProof` across calls.
   if pathElements.len != pathIndex.len * FieldElementSize:
     return err(
       "Invalid cached Merkle path: expected " &
@@ -498,48 +524,17 @@ proc buildWitness(
 
   var pathIndexVec = toVecUint8(pathIndex)
 
-  let identitySecret = bytesToCfrLe(credential.idSecretHash).valueOr:
-    return err(error)
-  defer:
-    ffi_cfr_free(identitySecret)
-
-  let userLimit = bytesToCfrLe(uint64ToField(userMessageLimit)).valueOr:
-    return err(error)
-  defer:
-    ffi_cfr_free(userLimit)
-
-  let messageIdFr = bytesToCfrLe(uint64ToField(uint64(messageId))).valueOr:
-    return err(error)
-  defer:
-    ffi_cfr_free(messageIdFr)
-
-  let x = hashToFieldLe(signal).valueOr:
-    return err(error)
-  defer:
-    ffi_cfr_free(x)
-
-  let externalNullifierBytes = computeExternalNullifier(epoch, rlnIdentifier).valueOr:
-    return err("Failed to compute external nullifier: " & error)
-
-  let externalNullifier = bytesToCfrLe(externalNullifierBytes).valueOr:
-    return err(error)
-  defer:
-    ffi_cfr_free(externalNullifier)
-
-  let witnessRes = ffi_rln_witness_input_new(
-    identitySecret,
-    userLimit,
-    messageIdFr,
+  buildWitnessFromPath(
     addr pathElementsVec,
     addr pathIndexVec,
-    x,
-    externalNullifier,
+    credential,
+    epoch,
+    rlnIdentifier,
+    signal,
+    messageId,
+    userMessageLimit,
+    "Failed to create witness from cached Merkle path: ",
   )
-
-  if witnessRes.ok.isNil:
-    return err(consumeError("Failed to create witness from cached Merkle path: ", witnessRes.err))
-
-  ok(witnessRes.ok)
 
 proc parseCredentialVec(vec: var Vec_CFr): RlnResult[IdentityCredential] =
   ## ffi_extended_key_gen returns a Vec_CFr of exactly 4 elements:
@@ -629,6 +624,13 @@ proc createRLNInstance*(resourcesPath: string = ""): RlnResult[RLNInstance] =
 proc newRLNInstance*(resourcesPath: string = ""): RlnResult[RLNInstance] =
   createRLNInstance(resourcesPath)
 
+proc close*(instance: RLNInstance) =
+  ## Release the underlying zerokit FFI_RLN box. Idempotent: subsequent calls
+  ## are no-ops. After close, the instance must not be used.
+  if not instance.isNil and not instance.ctx.isNil:
+    ffi_rln_free(instance.ctx)
+    instance.ctx = nil
+
 proc poseidonHash*(inputs: seq[seq[byte]]): RlnResult[array[32, byte]] =
   case inputs.len
   of 1:
@@ -640,12 +642,12 @@ proc poseidonHash*(inputs: seq[seq[byte]]): RlnResult[array[32, byte]] =
 
 proc computeExternalNullifier*(
     epoch: Epoch, rlnIdentifier: RlnIdentifier
-): RlnResult[ExternalNullifier] {.gcsafe.} =
+): RlnResult[ExternalNullifier] =
   poseidonPairLe(epoch, rlnIdentifier)
 
 proc computeRateCommitment*(
     idCommitment: IDCommitment, userMessageLimit: uint64
-): RlnResult[IDCommitment] {.gcsafe.} =
+): RlnResult[IDCommitment] =
   let limitField = uint64ToField(userMessageLimit)
   poseidonPairLe(idCommitment, limitField)
 
@@ -741,7 +743,7 @@ proc generatePartialProofCache*(
     credential: IdentityCredential,
     memberIndex: MembershipIndex,
     userMessageLimit: uint64 = UserMessageLimit,
-): RlnResult[PartialProofCache] {.gcsafe.} =
+): RlnResult[PartialProofCache] =
   discard flush(instance.ctx)
 
   let merkleProof = instance.getMerkleProofRaw(memberIndex).valueOr:
@@ -809,7 +811,7 @@ proc generateRlnProofWithWitness*(
     signal: openArray[byte],
     messageId: uint = 0,
     userMessageLimit: uint64 = UserMessageLimit,
-): RlnResult[RateLimitProof] {.gcsafe.} =
+): RlnResult[RateLimitProof] =
   discard flush(instance.ctx)
 
   let merkleProof = instance.getMerkleProofRaw(memberIndex).valueOr:
@@ -850,7 +852,7 @@ proc finishRlnProofWithCache*(
     signal: openArray[byte],
     messageId: uint = 0,
     userMessageLimit: uint64 = UserMessageLimit,
-): RlnResult[RateLimitProof] {.gcsafe.} =
+): RlnResult[RateLimitProof] =
   let currentRoot = instance.getMerkleRoot().valueOr:
     return err("Failed to get current root: " & error)
 
@@ -897,11 +899,14 @@ proc verifyRlnProof*(
     proof: RateLimitProof,
     rlnIdentifier: RlnIdentifier,
     signal: openArray[byte],
-    validRoots: seq[MerkleNode] = @[],
-): RlnResult[bool] {.gcsafe.} =
+    validRoots: seq[MerkleNode],
+): RlnResult[bool] =
   # v2.0.2: build the FFI_RLNProof directly from its field elements via
   # ffi_rln_proof_new, instead of round-tripping through the 290-byte
   # wire layout.
+  if validRoots.len == 0:
+    return err("verifyRlnProof requires at least one valid root")
+
   let externalNullifier = computeExternalNullifier(proof.epoch, rlnIdentifier).valueOr:
     return err("Failed to compute external nullifier: " & error)
 
@@ -948,25 +953,19 @@ proc verifyRlnProof*(
   var ctx = instance.ctx
   var proofHandle = proofRes.ok
 
-  if validRoots.len > 0:
-    var roots = toRootVec(validRoots).valueOr:
-      return err("Failed to build root vector: " & error)
-    defer:
-      ffi_vec_cfr_free(roots)
+  var roots = toRootVec(validRoots).valueOr:
+    return err("Failed to build root vector: " & error)
+  defer:
+    ffi_vec_cfr_free(roots)
 
-    let verifyRes = ffi_verify_with_roots(addr ctx, addr proofHandle, addr roots, x)
-    if hasError(verifyRes.err):
-      return err(consumeError("Proof verification failed: ", verifyRes.err))
-    return ok(verifyRes.ok)
-
-  let verifyRes = ffi_verify_rln_proof(addr ctx, addr proofHandle, x)
+  let verifyRes = ffi_verify_with_roots(addr ctx, addr proofHandle, addr roots, x)
   if hasError(verifyRes.err):
     return err(consumeError("Proof verification failed: ", verifyRes.err))
   ok(verifyRes.ok)
 
 proc recoverSecret*(
     instance: RLNInstance, proof1: RateLimitProof, proof2: RateLimitProof
-): RlnResult[array[32, byte]] {.gcsafe.} =
+): RlnResult[array[32, byte]] =
   discard instance
   if proof1.nullifier != proof2.nullifier:
     return err("Cannot recover secret: proofs have different nullifiers")

--- a/src/mix_rln_spam_protection/rln_interface.nim
+++ b/src/mix_rln_spam_protection/rln_interface.nim
@@ -2,9 +2,13 @@
 # Copyright (c) 2025 vacp2p
 # Licensed under either of Apache License 2.0 or MIT license.
 
-## Nim wrappers for zerokit RLN v2.0.0.
+## Nim wrappers for zerokit RLN v2.0.2 (non-stateless build).
 ## The higher-level API is kept intentionally close to the previous wrapper so
 ## the rest of the plugin can migrate with minimal churn.
+##
+## Build: this plugin requires zerokit's default features (pmtree-ft local
+## Merkle tree); the `stateless` cargo feature must NOT be enabled, as we
+## rely on `ffi_set_next_leaf`/`ffi_get_root`/`ffi_get_merkle_proof` etc.
 
 import std/os
 import results, chronicles
@@ -72,10 +76,6 @@ type
     ok: ptr FFI_MerkleProof
     err: Vec_uint8
 
-  CResultVecCFrVecU8 = object
-    ok: Vec_CFr
-    err: Vec_uint8
-
   CResultVecU8VecU8 = object
     ok: Vec_uint8
     err: Vec_uint8
@@ -96,8 +96,9 @@ type
     ctx*: ptr RLN
 
 const
-  SingleVersionByte = 0x00'u8
   FieldElementSize = 32
+  # Single-message-id RLN proof wire layout: outer version byte + 128-byte
+  # Groth16 + inner RLNProofValues (inner version + 5 field elements).
   ProofSerializationSize = 1 + ZksnarkProofByteSize + 1 + 5 * FieldElementSize
 
 proc computeExternalNullifier*(
@@ -107,8 +108,10 @@ proc computeExternalNullifier*(
 proc ffi_cfr_free(cfr: ptr CFr) {.importc: "ffi_cfr_free", cdecl.}
 proc ffi_cfr_to_bytes_le(cfr: ptr CFr): Vec_uint8 {.importc: "ffi_cfr_to_bytes_le", cdecl.}
 proc ffi_bytes_le_to_cfr(bytes: ptr Vec_uint8): CResultCFrPtrVecU8 {.importc: "ffi_bytes_le_to_cfr", cdecl.}
-proc ffi_hash_to_field_le(input: ptr Vec_uint8): CResultCFrPtrVecU8 {.importc: "ffi_hash_to_field_le", cdecl.}
-proc ffi_poseidon_hash_pair(a: ptr CFr, b: ptr CFr): CResultCFrPtrVecU8 {.importc: "ffi_poseidon_hash_pair", cdecl.}
+# v2.0.1: hash_to_field_le / poseidon_hash_pair return ptr CFr directly
+# (no Result wrapper) — caller MUST ffi_cfr_free the returned ptr.
+proc ffi_hash_to_field_le(input: ptr Vec_uint8): ptr CFr {.importc: "ffi_hash_to_field_le", cdecl.}
+proc ffi_poseidon_hash_pair(a: ptr CFr, b: ptr CFr): ptr CFr {.importc: "ffi_poseidon_hash_pair", cdecl.}
 
 proc ffi_vec_cfr_new(capacity: CSize): Vec_CFr {.importc: "ffi_vec_cfr_new", cdecl.}
 proc ffi_vec_cfr_push(v: ptr Vec_CFr, cfr: ptr CFr) {.importc: "ffi_vec_cfr_push", cdecl.}
@@ -118,8 +121,10 @@ proc ffi_vec_cfr_free(v: Vec_CFr) {.importc: "ffi_vec_cfr_free", cdecl.}
 proc ffi_vec_u8_free(v: Vec_uint8) {.importc: "ffi_vec_u8_free", cdecl.}
 proc ffi_c_string_free(s: Vec_uint8) {.importc: "ffi_c_string_free", cdecl.}
 
-proc ffi_extended_key_gen(): CResultVecCFrVecU8 {.importc: "ffi_extended_key_gen", cdecl.}
-proc ffi_seeded_extended_key_gen(seed: ptr Vec_uint8): CResultVecCFrVecU8 {.importc: "ffi_seeded_extended_key_gen", cdecl.}
+# v2.0.1: extended_key_gen / seeded_extended_key_gen return Vec_CFr directly
+# (no Result wrapper) — caller MUST ffi_vec_cfr_free the returned vec.
+proc ffi_extended_key_gen(): Vec_CFr {.importc: "ffi_extended_key_gen", cdecl.}
+proc ffi_seeded_extended_key_gen(seed: ptr Vec_uint8): Vec_CFr {.importc: "ffi_seeded_extended_key_gen", cdecl.}
 
 proc ffi_rln_new(treeDepth: CSize, config: cstring): CResultRLNPtrVecU8 {.importc: "ffi_rln_new", cdecl.}
 proc ffi_rln_new_with_params(
@@ -193,6 +198,16 @@ proc ffi_compute_id_secret(
 proc ffi_rln_proof_get_values(proof: ptr ptr FFI_RLNProof): ptr FFI_RLNProofValues {.importc: "ffi_rln_proof_get_values", cdecl.}
 proc ffi_rln_proof_to_bytes_le(proof: ptr ptr FFI_RLNProof): CResultVecU8VecU8 {.importc: "ffi_rln_proof_to_bytes_le", cdecl.}
 proc ffi_bytes_le_to_rln_proof(bytes: ptr Vec_uint8): CResultProofPtrVecU8 {.importc: "ffi_bytes_le_to_rln_proof", cdecl.}
+# v2.0.2: construct an RLNProof directly from its field elements (single
+# message-id variant), avoiding the manual 290-byte wire layout.
+proc ffi_rln_proof_new(
+  groth16Bytes: ptr Vec_uint8,
+  root: ptr CFr,
+  externalNullifier: ptr CFr,
+  x: ptr CFr,
+  y: ptr CFr,
+  nullifier: ptr CFr,
+): CResultProofPtrVecU8 {.importc: "ffi_rln_proof_new", cdecl.}
 proc ffi_rln_proof_free(p: ptr FFI_RLNProof) {.importc: "ffi_rln_proof_free", cdecl.}
 
 proc ffi_rln_partial_proof_to_bytes_le(partial_proof: ptr ptr FFI_RLNPartialProof): CResultVecU8VecU8 {.importc: "ffi_rln_partial_proof_to_bytes_le", cdecl.}
@@ -292,10 +307,10 @@ proc bytesToCfrLe(data: openArray[byte]): RlnResult[ptr CFr] =
 
 proc hashToFieldLe(data: openArray[byte]): RlnResult[ptr CFr] =
   var vec = toVecUint8(data)
-  let res = ffi_hash_to_field_le(addr vec)
-  if not res.ok.isNil:
-    return ok(res.ok)
-  err(consumeError("Failed to hash to field: ", res.err))
+  let cfr = ffi_hash_to_field_le(addr vec)
+  if cfr.isNil:
+    return err("Failed to hash to field")
+  ok(cfr)
 
 proc poseidonPairLe(a, b: openArray[byte]): RlnResult[array[32, byte]] =
   let aPtr = bytesToCfrLe(a).valueOr:
@@ -308,13 +323,13 @@ proc poseidonPairLe(a, b: openArray[byte]): RlnResult[array[32, byte]] =
   defer:
     ffi_cfr_free(bPtr)
 
-  let res = ffi_poseidon_hash_pair(aPtr, bPtr)
-  if res.ok.isNil:
-    return err(consumeError("Poseidon hash failed: ", res.err))
+  let cfr = ffi_poseidon_hash_pair(aPtr, bPtr)
+  if cfr.isNil:
+    return err("Poseidon hash failed")
   defer:
-    ffi_cfr_free(res.ok)
+    ffi_cfr_free(cfr)
 
-  cfrToBytesLe(res.ok)
+  cfrToBytesLe(cfr)
 
 proc cfrResultToBytes(res: CResultCFrPtrVecU8, prefix: string): RlnResult[array[32, byte]] =
   if res.ok.isNil:
@@ -341,39 +356,6 @@ proc getCurrentRootRaw(instance: RLNInstance): RlnResult[MerkleNode] =
   defer:
     ffi_cfr_free(rootPtr)
   cfrToBytesLe(rootPtr)
-
-proc buildProofBytesLe(
-    proof: RateLimitProof, rlnIdentifier: RlnIdentifier
-): RlnResult[seq[byte]] =
-  let externalNullifier = computeExternalNullifier(proof.epoch, rlnIdentifier).valueOr:
-    return err("Failed to compute external nullifier: " & error)
-
-  var encoded = newSeq[byte](ProofSerializationSize)
-  var offset = 0
-
-  encoded[offset] = SingleVersionByte
-  inc offset
-
-  copyMem(addr encoded[offset], unsafeAddr proof.proof[0], ZksnarkProofByteSize)
-  offset += ZksnarkProofByteSize
-
-  encoded[offset] = SingleVersionByte
-  inc offset
-
-  copyMem(addr encoded[offset], unsafeAddr proof.merkleRoot[0], HashByteSize)
-  offset += HashByteSize
-
-  copyMem(addr encoded[offset], unsafeAddr externalNullifier[0], HashByteSize)
-  offset += HashByteSize
-
-  copyMem(addr encoded[offset], unsafeAddr proof.shareX[0], HashByteSize)
-  offset += HashByteSize
-
-  copyMem(addr encoded[offset], unsafeAddr proof.shareY[0], HashByteSize)
-  offset += HashByteSize
-
-  copyMem(addr encoded[offset], unsafeAddr proof.nullifier[0], HashByteSize)
-  ok(encoded)
 
 proc proofPtrToRateLimitProof(
     proofPtr: ptr FFI_RLNProof, epoch: Epoch
@@ -559,22 +541,18 @@ proc buildWitness(
 
   ok(witnessRes.ok)
 
-proc membershipKeyGen*(): RlnResult[IdentityCredential] =
-  let res = ffi_extended_key_gen()
-  if hasError(res.err):
-    return err(consumeError("Key generation failed: ", res.err))
-  defer:
-    ffi_vec_cfr_free(res.ok)
-
-  if int(ffi_vec_cfr_len(addr res.ok)) != 4:
+proc parseCredentialVec(vec: var Vec_CFr): RlnResult[IdentityCredential] =
+  ## ffi_extended_key_gen returns a Vec_CFr of exactly 4 elements:
+  ## [ idTrapdoor, idNullifier, idSecretHash, idCommitment ].
+  if int(ffi_vec_cfr_len(addr vec)) != 4:
     return err("Unexpected credential element count")
 
   var cred: IdentityCredential
   let fields = [
-    ffi_vec_cfr_get(addr res.ok, 0),
-    ffi_vec_cfr_get(addr res.ok, 1),
-    ffi_vec_cfr_get(addr res.ok, 2),
-    ffi_vec_cfr_get(addr res.ok, 3),
+    ffi_vec_cfr_get(addr vec, 0),
+    ffi_vec_cfr_get(addr vec, 1),
+    ffi_vec_cfr_get(addr vec, 2),
+    ffi_vec_cfr_get(addr vec, 3),
   ]
   for field in fields:
     if field.isNil:
@@ -586,35 +564,19 @@ proc membershipKeyGen*(): RlnResult[IdentityCredential] =
   cred.idCommitment = cfrToBytesLe(fields[3]).valueOr: return err(error)
 
   ok(cred)
+
+proc membershipKeyGen*(): RlnResult[IdentityCredential] =
+  var vec = ffi_extended_key_gen()
+  defer:
+    ffi_vec_cfr_free(vec)
+  parseCredentialVec(vec)
 
 proc membershipKeyGen*(seed: openArray[byte]): RlnResult[IdentityCredential] =
   var seedVec = toVecUint8(seed)
-  let res = ffi_seeded_extended_key_gen(addr seedVec)
-  if hasError(res.err):
-    return err(consumeError("Seeded key generation failed: ", res.err))
+  var vec = ffi_seeded_extended_key_gen(addr seedVec)
   defer:
-    ffi_vec_cfr_free(res.ok)
-
-  if int(ffi_vec_cfr_len(addr res.ok)) != 4:
-    return err("Unexpected credential element count")
-
-  var cred: IdentityCredential
-  let fields = [
-    ffi_vec_cfr_get(addr res.ok, 0),
-    ffi_vec_cfr_get(addr res.ok, 1),
-    ffi_vec_cfr_get(addr res.ok, 2),
-    ffi_vec_cfr_get(addr res.ok, 3),
-  ]
-  for field in fields:
-    if field.isNil:
-      return err("Missing credential field from zerokit")
-
-  cred.idTrapdoor = cfrToBytesLe(fields[0]).valueOr: return err(error)
-  cred.idNullifier = cfrToBytesLe(fields[1]).valueOr: return err(error)
-  cred.idSecretHash = cfrToBytesLe(fields[2]).valueOr: return err(error)
-  cred.idCommitment = cfrToBytesLe(fields[3]).valueOr: return err(error)
-
-  ok(cred)
+    ffi_vec_cfr_free(vec)
+  parseCredentialVec(vec)
 
 proc generateMembershipKey*(): RlnResult[IdentityCredential] =
   membershipKeyGen()
@@ -937,12 +899,44 @@ proc verifyRlnProof*(
     signal: openArray[byte],
     validRoots: seq[MerkleNode] = @[],
 ): RlnResult[bool] {.gcsafe.} =
-  let proofBytes = buildProofBytesLe(proof, rlnIdentifier).valueOr:
-    return err(error)
-  var proofVec = toVecUint8(proofBytes)
-  let proofRes = ffi_bytes_le_to_rln_proof(addr proofVec)
+  # v2.0.2: build the FFI_RLNProof directly from its field elements via
+  # ffi_rln_proof_new, instead of round-tripping through the 290-byte
+  # wire layout.
+  let externalNullifier = computeExternalNullifier(proof.epoch, rlnIdentifier).valueOr:
+    return err("Failed to compute external nullifier: " & error)
+
+  var groth16Vec = toVecUint8(proof.proof)
+
+  let rootFr = bytesToCfrLe(proof.merkleRoot).valueOr:
+    return err("Failed to convert root: " & error)
+  defer:
+    ffi_cfr_free(rootFr)
+
+  let extNullFr = bytesToCfrLe(externalNullifier).valueOr:
+    return err("Failed to convert external nullifier: " & error)
+  defer:
+    ffi_cfr_free(extNullFr)
+
+  let shareXFr = bytesToCfrLe(proof.shareX).valueOr:
+    return err("Failed to convert shareX: " & error)
+  defer:
+    ffi_cfr_free(shareXFr)
+
+  let shareYFr = bytesToCfrLe(proof.shareY).valueOr:
+    return err("Failed to convert shareY: " & error)
+  defer:
+    ffi_cfr_free(shareYFr)
+
+  let nullifierFr = bytesToCfrLe(proof.nullifier).valueOr:
+    return err("Failed to convert nullifier: " & error)
+  defer:
+    ffi_cfr_free(nullifierFr)
+
+  let proofRes = ffi_rln_proof_new(
+    addr groth16Vec, rootFr, extNullFr, shareXFr, shareYFr, nullifierFr
+  )
   if proofRes.ok.isNil:
-    return err(consumeError("Failed to deserialize proof for verification: ", proofRes.err))
+    return err(consumeError("Failed to build RLN proof for verification: ", proofRes.err))
   defer:
     ffi_rln_proof_free(proofRes.ok)
 


### PR DESCRIPTION
## Summary

Migrates the RLN FFI wrapper from zerokit v2.0.0 to v2.0.2, aligning this plugin with the zerokit pin used by [logos-delivery#3868](https://github.com/logos-messaging/logos-delivery/pull/3868). Both repos now build against zerokit commit `5e64cb8` (tag `v2.0.2`).

**Base:** `migrate-to-libp2p_mix` (stacks on top of #6). Once #6 lands, this PR's diff against `main` will collapse to just these 2 commits.

Unlike logos-delivery, this plugin keeps an **offchain** Merkle tree — so zerokit must be built with default features (NOT `--features stateless`). `ffi_set_next_leaf` / `ffi_get_root` / `ffi_get_merkle_proof` remain in use.

## What changed

**Commit 1 — `feat: migrate to zerokit v2.0.2`**
- 4 FFI signatures updated for v2.0.1's "drop `Result` from hash/keygen" change:
  - `ffi_hash_to_field_le` → `ptr CFr`
  - `ffi_poseidon_hash_pair` → `ptr CFr`
  - `ffi_extended_key_gen` → `Vec_CFr`
  - `ffi_seeded_extended_key_gen` → `Vec_CFr`
- `verifyRlnProof` rewritten to use v2.0.2's new `ffi_rln_proof_new` constructor instead of round-tripping through the manual 290-byte wire layout (drops `buildProofBytesLe` + `SingleVersionByte`). Matches the shape of logos-delivery's `wrappers.nim`.
- `membershipKeyGen` / seeded variant consolidated through a shared `parseCredentialVec`.
- README bumped to v2.0.2; explicit note that the `stateless` cargo feature must NOT be enabled.

**Commit 2 — `refactor(rln-ffi): tighten ffi wrapper after v2.0.2 migration`**
- `verifyRlnProof` now requires `validRoots` (both call sites already passed it); dead `ffi_verify_rln_proof` import + fallback branch removed.
- Added `ffi_rln_free` import + `close*(instance)` proc for explicit teardown.
- Hoisted `gcsafe` into the file-level `{.push.}`; dropped 9 per-proc annotations.
- Extracted `buildWitnessFromPath`: both `buildWitness` overloads now share the 5-scalar witness setup, while each keeps its specialized path-prep (fresh-FFI = zero-copy passthrough; cached-bytes = `Vec_CFr` reconstruction).
- Dropped now-unused `ffi_bytes_le_to_rln_proof` import.

## Test plan

- [x] Local rebuild of `librln.a` from zerokit `v2.0.2` (default features)
- [x] `nimble test` — 28/28 pass (proof gen/verify roundtrip, partial-proof cache, root-window invalidation, epoch-change callback, spam detection / secret recovery)
- [x] Tests re-verified after rebase onto `migrate-to-libp2p_mix` — still 28/28
- [ ] Integration test with logos-delivery using its `feat/bump_zerokit_2.0.1` branch — needs to confirm interop with the shared zerokit ABI when both processes link the same v2.0.2 build
- [ ] Update the consuming Nimble project's `librln.a` build step to checkout zerokit `v2.0.2` (one-liner doc change in downstream)

## Pending follow-ups

- Integration testing against logos-delivery as noted above. The plugin alone is green; cross-repo integration is the remaining unknown before this can be considered shippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
